### PR TITLE
Add post: Priveil — pseudonymisation for Australian financial data

### DIFF
--- a/collections/_posts/2026-06-28-priveil.md
+++ b/collections/_posts/2026-06-28-priveil.md
@@ -1,0 +1,194 @@
+---
+layout: post
+title: "Priveil: pseudonymisation for Australian financial data"
+description: Introducing Priveil — a pragmatic tool for detecting and replacing PII in financial text. Not anonymisation. Not a silver bullet. But better than nothing.
+date: 2026-06-28 00:00:00 +1000
+author: mitchell
+image: '/images/priveil.jpg'
+tags: [privacy, python, AI, MCP, australia]
+tags_color: '#2563eb'
+---
+
+<p style="font-size: 0.85rem; color: var(--color-base-text-2); margin: 0 0 1.25rem;">Photo by <a href="https://unsplash.com/@borisview?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">boris misevic</a> on <a href="https://unsplash.com/photos/red-wooden-door-with-a-locked-padlock-pFw0Eh3-6T4?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a></p>
+
+Before I talk about what Priveil does, I want to be honest about what it doesn't do — because that distinction matters more than any feature.
+
+**Priveil does not anonymise data.**
+
+It pseudonymises it. Those two words sound similar, but the difference is the difference between a locked door and an open one with a sign saying "nothing to see here." True anonymisation — the kind that withstands an adversary with auxiliary information, today and in ten years — is an [extremely hard problem](https://desfontain.es/blog/trustworthy-anonymization.html). The only approach that comes with a mathematical guarantee is differential privacy, and differential privacy works on aggregations, not on text. If you need data that is safe to publish without downstream controls, no pattern-matching tool will get you there.
+
+With that said: most systems in practice aren't trying to publish to the world. They're trying to keep PII out of logs, reduce exposure when data crosses trust boundaries, improve compliance posture, and stop names and Tax File Numbers showing up in Slack. For those purposes, a good pseudonymisation service is genuinely useful — and that's what Priveil is.
+
+## Why anonymisation is hard
+
+The privacy research literature has established three reasons why find-and-replace approaches can't produce truly anonymous data:
+
+**Data is more identifying than it appears.** A name and a postcode together uniquely identify most people. A sequence of transactions, a writing style, a combination of fields that each look innocuous — any of these can be as identifying as a name. You can't enumerate what an attacker might use, so you can't enumerate what to remove.
+
+**Auxiliary data is an unknown variable.** Information that looks private may already be public for specific individuals. Politicians, athletes, executives. Data that's safe today may become identifying after an unrelated breach. A pseudonymisation scheme that doesn't account for what an attacker already knows provides no robust guarantee — it only needs to be wrong once.
+
+**Attacks improve over time.** AI-assisted reconstruction, linkage attacks, and re-identification techniques are improving. The 2016 Australian Medicare dataset that was [publicly released and then withdrawn](https://www.themandarin.com.au/69028-human-services-takes-down-de-identified-medicare-data-after-re-identification-concerns/) is a case in point: patterns that appeared safe turned out to be linkable. Mitigating only known attacks isn't enough.
+
+I've written about this at more length in [Too Unique to Hide]({% post_url 2025-12-24-too-unique-to-hide %}) and [Database Reconstruction Attacks]({% post_url 2019-10-14-database-reconstruction-attacks %}).
+
+## What Priveil actually is
+
+[Priveil](https://github.com/mitchelllisle/priveil) is a pseudonymisation service built for Australian financial services contexts. It runs as a FastAPI service and wraps [Microsoft Presidio](https://microsoft.github.io/presidio/) with a set of purpose-built recognisers for Australian identifiers — Tax File Numbers, Medicare numbers, BSBs, ABNs, ACNs, and Australian phone formats — each with checksum validation where the issuing authority publishes an algorithm.
+
+| Entity | Description | Validated |
+|--------|-------------|-----------|
+| `AU_TFN` | Tax File Number | ATO mod-11 checksum |
+| `AU_MEDICARE` | Medicare card | DVA checksum |
+| `AU_ABN` | Australian Business Number | ATO mod-89 |
+| `AU_ACN` | Australian Company Number | ASIC complement-of-10 |
+| `AU_BSB` | Bank State Branch | Format |
+| `AU_ACCOUNT_NUMBER` | Bank account | Requires BSB context |
+| `AU_PHONE` | Mobile / landline | 04XX, +61 4XX, STD |
+
+Standard Presidio types (`PERSON`, `EMAIL_ADDRESS`, `CREDIT_CARD`, `LOCATION`, `DATE_TIME`) are detected alongside these.
+
+---
+
+## Three endpoints
+
+### `/detect` — find what's there
+
+```bash
+curl -X POST http://localhost:8000/detect \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "Jane Smith TFN 123 456 782, BSB 062-000, jane@bank.com.au",
+    "mode": "judge"
+  }'
+```
+
+```json
+{
+  "entities": [
+    { "text": "Jane Smith",          "entity_type": "PERSON",        "sensitivity": "high",     "score": 0.85 },
+    { "text": "123 456 782",         "entity_type": "AU_TFN",        "sensitivity": "critical", "score": 1.0  },
+    { "text": "062-000",             "entity_type": "AU_BSB",         "sensitivity": "high",     "score": 0.85 },
+    { "text": "jane@bank.com.au",      "entity_type": "EMAIL_ADDRESS",  "sensitivity": "medium",   "score": 1.0  }
+  ],
+  "input_hash": "sha256:..."
+}
+```
+
+The `mode` field controls whether detections are passed through an LLM to remove false positives (`"judge"`) or returned raw (`"fast"`). The `input_hash` is a SHA-256 audit trail of the original text — useful when you want to prove you processed a document without storing it.
+
+### `/anonymise` — replace what you found
+
+```bash
+curl -X POST http://localhost:8000/anonymise \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Jane Smith TFN 123 456 782", "mode": "judge"}'
+```
+
+```json
+{
+  "anonymised_text": "<PERSON> TFN ***-***-***",
+  "entity_map": {
+    "Jane Smith":  "<PERSON>",
+    "123 456 782": "***-***-***"
+  }
+}
+```
+
+Replacements use sensible defaults by entity type (TFNs become `***-***-***`, credit cards get last-four masking, locations become `<LOCATION>`), but every operator is overridable per-request:
+
+```json
+{
+  "text": "Contact Jane Smith on 0412 345 678",
+  "operator_overrides": { "PERSON": "redact", "AU_PHONE": "mask" }
+}
+```
+
+Available operators: `replace`, `mask`, `redact`, `hash`.
+
+One note on the `entity_map`: it records original PII spans as keys and must be treated as sensitive data. It's useful for audits, but it's not a reversible index — multiple spans may collapse to the same label, so it doesn't reconstruct the original document on its own.
+
+### `/assess` — risk profile a document
+
+The most interesting endpoint. Backed by an LLM judge, it produces a risk profile: overall sensitivity tier, applicable Australian regulatory frameworks, and handling guidance.
+
+```bash
+curl -X POST http://localhost:8000/assess \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "Applicant Jane Smith TFN 123 456 782. BSB 062-000.",
+    "context": "Australian home loan application"
+  }'
+```
+
+```json
+{
+  "overall_sensitivity": "critical",
+  "risk_summary": "Contains TFN and BSB — highest regulatory exposure",
+  "categories": ["identity", "financial"],
+  "regulatory_flags": ["Privacy Act s16B", "ATO data standards"],
+  "recommended_handling": "Encrypt at rest, restrict to need-to-know, purge after 90 days",
+  "entity_breakdown": [
+    { "entity_type": "AU_TFN", "sensitivity": "critical", "count": 1 },
+    { "entity_type": "AU_BSB", "sensitivity": "high",     "count": 1 }
+  ]
+}
+```
+
+This is the endpoint that answers "I found some PII — but how worried should I actually be, and what do I need to do about it?" It understands Australian context: Privacy Act obligations, ATO data standards, ASIC requirements.
+
+---
+
+## MCP server
+
+Priveil also ships an MCP server, which means you can wire it directly into Claude Desktop, Cursor, or any other MCP-aware client — and have the AI detect, pseudonymise, and assess PII without leaving your chat.
+
+Add this to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "priveil": {
+      "command": "uv",
+      "args": ["run", "--project", "/path/to/priveil", "python", "-m", "priveil.mcp"],
+      "env": {
+        "PRIVEIL_JUDGE_MODEL": "anthropic:claude-sonnet-4-6",
+        "ANTHROPIC_API_KEY": "<your-key>"
+      }
+    }
+  }
+}
+```
+
+Three tools become available to the model: `detect`, `anonymise`, and `assess`. The practical use case: you paste a document into a chat, ask the AI to clean it before it goes into a log or gets sent downstream, and the AI calls Priveil's tools directly rather than attempting pattern-matching itself. The model gets pseudonymised text; the raw PII never makes it into the context window beyond that initial document.
+
+---
+
+## Running it
+
+```bash
+git clone https://github.com/mitchelllisle/priveil
+cd priveil
+
+# copy and configure .env
+cp .env.example .env
+
+# install and serve
+make install
+make serve
+```
+
+The API comes up at `http://localhost:8000`, with interactive docs at `http://localhost:8000/docs`. Docker is also supported: `make docker-serve`.
+
+The LLM judge is optional — `mode=fast` and `mode=judge` both work, but judge mode and `/assess` require `PRIVEIL_JUDGE_MODEL` to be set (format: `provider:model`, e.g. `anthropic:claude-sonnet-4-6`).
+
+---
+
+## What it's good for, and what it isn't
+
+Good for: keeping PII out of logs and analytics pipelines; reducing accidental exposure when data crosses trust boundaries; improving compliance posture in Australian financial services; making data *less obviously identifying* for operational purposes. These are real and valuable things.
+
+Not good for: publishing data publicly; satisfying a regulator that the data is "truly anonymous"; any scenario where an adversary might have auxiliary information that could enable linkage.
+
+The codebase is deliberate about this distinction — even the README warns that the word "anonymise" appears throughout because it's what practitioners say, not because it's accurate.
+
+If you're handling Australian financial data and want something that keeps PII from leaking across service boundaries, check it out on [GitHub](https://github.com/mitchelllisle/priveil). For further reading on why this stuff is genuinely hard, Damien Desfontaines' [*What anonymization techniques can you trust?*](https://desfontain.es/blog/trustworthy-anonymization.html) is the place to start.


### PR DESCRIPTION
Adds the Priveil blog post with hero image.

- Unsplash attribution for hero image (boris misevic)
- Example emails use `bank.com.au` instead of `westpac.com.au`