### PR TITLE
post(priveil): add LLM provider warnings and egress guidance

### DIFF
--- a/collections/_posts/2026-06-28-priveil.md
+++ b/collections/_posts/2026-06-28-priveil.md
@@ -76,6 +76,8 @@ curl -X POST http://localhost:8000/detect \
 
 The `mode` field controls whether detections are passed through an LLM to remove false positives (`"judge"`) or returned raw (`"fast"`). The `input_hash` is a SHA-256 audit trail of the original text — useful when you want to prove you processed a document without storing it.
 
+> **`mode="judge"` sends raw text to your LLM provider.** The un-redacted input — TFNs, Medicare numbers, names, account details — goes to whatever model you've configured before any pseudonymisation happens. If that model is hosted by Anthropic or OpenAI, your most sensitive data just left your infrastructure. More on this below.
+
 ### `/anonymise` — replace what you found
 
 ```bash
@@ -138,28 +140,55 @@ This is the endpoint that answers "I found some PII — but how worried should I
 
 ---
 
+## The AI provider problem
+
+Priveil's LLM judge is genuinely useful — it removes false positives that pure pattern-matching can't catch. But it creates a problem that deserves a straight answer: **`mode="judge"` and `/assess` send your raw, un-redacted text to whatever LLM provider you've configured.** That text may contain TFNs, Medicare numbers, bank account details, and full names. If your judge is `anthropic:claude-sonnet-4-6` or `openai:gpt-4o`, that data is being sent to a commercial third-party API governed by their infrastructure, their data retention policies, and their own disclosure obligations.
+
+This is the central irony. You're using Priveil to comply with the Privacy Act and ATO data standards — and if you configure it carelessly, you've handed that same data to a party you may not be authorised to share it with. Regulations don't stop applying because the data was in a JSON request body.
+
+**What you should actually do:**
+
+For real regulated data, run the judge on a self-hosted or locally-run model. Priveil supports any OpenAI-compatible endpoint via `PRIVEIL_JUDGE_BASE_URL`, which means you can point it at:
+
+- [Ollama](https://ollama.com/) running locally — `llama3`, `mistral`, or any model with reasonable instruction-following
+- A self-hosted [vLLM](https://github.com/vllm-project/vllm) or [llama.cpp](https://github.com/ggerganov/llama.cpp) server
+- An internal enterprise gateway in front of a cloud model, with appropriate data processing agreements, training opt-outs, and regional controls in place
+
+If you must use a cloud provider, you need three things confirmed before you do: a data processing agreement (DPA) covering this category of data, training on your inputs disabled, and explicit authorisation under your organisation's information security policy. Without all three, you are likely breaching the very obligations Priveil is supposed to help with.
+
+**`mode="fast"` keeps everything local.** No LLM involvement means no PII egress beyond Priveil itself. You'll get more false positives, but for many preprocessing workflows — especially where a human reviewer sees the output — that's an acceptable tradeoff. For batch pipelines that feed into downstream systems, `fast` mode plus a review step is often the right architecture.
+
+If you skip the judge entirely (`mode="fast"` everywhere, no `/assess` calls), Priveil never makes an outbound network request for your data. That's a legitimate and often correct deployment.
+
+---
+
 ## MCP server
 
-Priveil also ships an MCP server, which means you can wire it directly into Claude Desktop, Cursor, or any other MCP-aware client — and have the AI detect, pseudonymise, and assess PII without leaving your chat.
+Priveil also ships an MCP server, which means you can wire it directly into Claude Desktop, Cursor, or any other MCP-aware client.
 
-Add this to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+> **Stop before you do this with real data.** When you paste a document into Claude Desktop, that document — raw, with whatever PII it contains — is sent to Anthropic as part of your chat. That's true regardless of what Priveil does afterwards. The MCP integration is genuinely useful for working with *synthetic or already-pseudonymised* data, or for personal/development workflows where you understand and accept what's happening. For production financial data, it is not the right setup.
+
+With that said, here's how it works. Add this to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 ```json
 {
   "mcpServers": {
     "priveil": {
-      "command": "uv",
-      "args": ["run", "--project", "/path/to/priveil", "python", "-m", "priveil.mcp"],
+      "command": "priveil-mcp",
       "env": {
-        "PRIVEIL_JUDGE_MODEL": "anthropic:claude-sonnet-4-6",
-        "ANTHROPIC_API_KEY": "<your-key>"
+        "PRIVEIL_JUDGE_MODEL": "ollama:llama3",
+        "PRIVEIL_JUDGE_BASE_URL": "http://localhost:11434/v1"
       }
     }
   }
 }
 ```
 
-Three tools become available to the model: `detect`, `anonymise`, and `assess`. The practical use case: you paste a document into a chat, ask the AI to clean it before it goes into a log or gets sent downstream, and the AI calls Priveil's tools directly rather than attempting pattern-matching itself. The model gets pseudonymised text; the raw PII never makes it into the context window beyond that initial document.
+Using a local model via `PRIVEIL_JUDGE_BASE_URL` means Priveil's judge stays on your machine. That doesn't change the fact that pasting raw data into Claude Desktop sends it to Anthropic — but it does mean the judge isn't also forwarding it to a second external service.
+
+If you're using this for exploration or development against non-production data, and you're comfortable with Anthropic receiving the content, the `anthropic:claude-sonnet-4-6` judge works well. Just be deliberate about that choice.
+
+Three tools become available to the model: `detect`, `anonymise`, and `assess`. The practical use case: you paste a document into a chat, ask the AI to clean it before it goes into a log or gets sent downstream, and the AI calls Priveil's tools directly rather than attempting pattern-matching itself.
 
 ---
 
@@ -179,7 +208,7 @@ make serve
 
 The API comes up at `http://localhost:8000`, with interactive docs at `http://localhost:8000/docs`. Docker is also supported: `make docker-serve`.
 
-The LLM judge is optional — `mode=fast` and `mode=judge` both work, but judge mode and `/assess` require `PRIVEIL_JUDGE_MODEL` to be set (format: `provider:model`, e.g. `anthropic:claude-sonnet-4-6`).
+The LLM judge is optional — `mode=fast` and `mode=judge` both work, but judge mode and `/assess` require `PRIVEIL_JUDGE_MODEL` to be set (format: `provider:model`). For local use, set `PRIVEIL_JUDGE_BASE_URL` to point at an Ollama or llama.cpp server and use any OpenAI-compatible model string. For regulated data in any context, this is the right path.
 
 ---
 
@@ -188,6 +217,8 @@ The LLM judge is optional — `mode=fast` and `mode=judge` both work, but judge 
 Good for: keeping PII out of logs and analytics pipelines; reducing accidental exposure when data crosses trust boundaries; improving compliance posture in Australian financial services; making data *less obviously identifying* for operational purposes. These are real and valuable things.
 
 Not good for: publishing data publicly; satisfying a regulator that the data is "truly anonymous"; any scenario where an adversary might have auxiliary information that could enable linkage.
+
+**Also not a substitute for thinking about where your AI runs.** The judge and assess features are powerful, but using them with a commercial API provider without appropriate authorisation and agreements undermines the entire point. The tool helps — the configuration determines whether that help is net positive or net negative for your privacy posture. Use a local model, or know exactly what you've agreed to with whoever is hosting yours.
 
 The codebase is deliberate about this distinction — even the README warns that the word "anonymise" appears throughout because it's what practitioners say, not because it's accurate.
 


### PR DESCRIPTION
## What

Aligns the Priveil article with how the README actually talks about PII and LLM egress risk — which the original post glossed over.

## Why

The original article showed `anthropic:claude-sonnet-4-6` as the example judge config with no caveats, and claimed the MCP integration meant "raw PII never makes it into the context window" — which is wrong (pasting a document into Claude Desktop sends it to Anthropic regardless of what Priveil does).

## Changes

- **Inline warning on `mode="judge"`**: makes explicit that raw, un-redacted text goes to the configured LLM provider before pseudonymisation
- **New section — "The AI provider problem"**: names the core contradiction, recommends self-hosted models (Ollama, vLLM, llama.cpp, `PRIVEIL_JUDGE_BASE_URL`), states the three requirements for cloud provider use (DPA, training opt-out, ISP authorisation), and positions `mode=fast` as a legitimate zero-egress architecture
- **MCP section rewrite**: corrects the safety claim, switches example config to a local Ollama judge, acknowledges the two separate egress paths (the chat and the judge model)
- **Running it**: surfaces `PRIVEIL_JUDGE_BASE_URL` as the local path
- **Closing section**: adds provider choice as an explicit part of responsible use