### PR TITLE
post: add GitHub/PyPI callout to top of priveil post

### DIFF
--- a/collections/_posts/2026-06-28-priveil.md
+++ b/collections/_posts/2026-06-28-priveil.md
@@ -11,6 +11,14 @@ tags_color: '#2563eb'
 
 <p style="font-size: 0.85rem; color: var(--color-base-text-2); margin: 0 0 1.25rem;">Photo by <a href="https://unsplash.com/@borisview?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">boris misevic</a> on <a href="https://unsplash.com/photos/red-wooden-door-with-a-locked-padlock-pFw0Eh3-6T4?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a></p>
 
+<div style="display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; padding: 0.85rem 1.1rem; margin: 0 0 1.75rem; border: 1px solid var(--color-border); border-radius: 6px; background: var(--color-bg-secondary, transparent); font-size: 0.9rem;">
+  <strong style="white-space: nowrap;"><a href="https://github.com/mitchelllisle/priveil" style="text-decoration: none;">GitHub — mitchelllisle/priveil ↗</a></strong>
+  <span style="color: var(--color-base-text-2);">·</span>
+  <code style="background: var(--color-bg-tertiary, rgba(0,0,0,0.06)); padding: 0.15em 0.5em; border-radius: 4px; white-space: nowrap;">pip install priveil</code>
+  <span style="color: var(--color-base-text-2);">·</span>
+  <span style="color: var(--color-base-text-2); white-space: nowrap;">Python · FastAPI · MIT</span>
+</div>
+
 Before I talk about what Priveil does, I want to be honest about what it doesn't do — because that distinction matters more than any feature.
 
 **Priveil does not anonymise data.**


### PR DESCRIPTION
Adds a slim info strip immediately below the hero photo credit — before any prose — so readers know upfront this is a real, installable project.

The strip shows:
- **GitHub — mitchelllisle/priveil ↗** (linked)
- `pip install priveil` (code badge)
- `Python · FastAPI · MIT`

Uses existing CSS variables (`--color-border`, `--color-bg-secondary`, etc.) so it respects light/dark mode and wraps on narrow viewports.