### PR TITLE
Show publish date and tags on all posts

### DIFF
--- a/_includes/framework/card-post.html
+++ b/_includes/framework/card-post.html
@@ -4,7 +4,7 @@
 {% assign icon = include.icon %}
 {% assign fa_icon = include.fa_icon %}
 {% assign url = include.url %}
-{% assign date = include.date %}
+{% assign card_date = include.date %}
 {% assign authors = include.authors %}
 {% if include.author and authors == nil %}
   {% assign authors = include.author | split: "," %}
@@ -24,7 +24,7 @@
   {% endif %}
 
   <div class="card-content">
-    {% if authors or date %}
+    {% if authors or card_date %}
       <div class="card-meta">
 
         {% if authors %}
@@ -38,9 +38,9 @@
           </div>
         {% endif %}
 
-        {% if date %}
+        {% if card_date %}
           <div class="card-date">
-            <span class="post-date-date">{{ date | date_to_long_string }}</span>
+            <span class="post-date-date">{{ card_date | date_to_long_string }}</span>
           </div>
         {% endif %}
 

--- a/_includes/theme/cards/card-post.html
+++ b/_includes/theme/cards/card-post.html
@@ -4,7 +4,7 @@
 {% assign icon = include.icon %}
 {% assign fa_icon = include.fa_icon %}
 {% assign url = include.url %}
-{% assign date = include.date %}
+{% assign card_date = include.date %}
 {% assign authors = include.authors %}
 {% if include.author and authors == nil %}
   {% assign authors = include.author | split: "," %}
@@ -24,7 +24,7 @@
   {% endif %}
 
   <div class="card-content">
-    {% if authors or date %}
+    {% if authors or card_date %}
       <div class="card-meta">
 
         {% if authors %}
@@ -38,9 +38,9 @@
           </div>
         {% endif %}
 
-        {% if date %}
+        {% if card_date %}
           <div class="card-date">
-            <span class="post-date-date">{{ date | date_to_long_string }}</span>
+            <span class="post-date-date">{{ card_date | date_to_long_string }}</span>
           </div>
         {% endif %}
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -85,15 +85,16 @@ body_classes: page-home
 
       {% for card in cards limit: limit %}
       {% assign card_thumbnail = card.thumbnail | default: card.image %}
+      {% assign card_date = card.date | date: "%Y-%m-%d" %}
       <div class="col-12 col-md-4 {{ columns }} {% if forloop.first %}mt-0{% endif %} {% if forloop.last %}mb-0{% endif %} mb-3 mb-md-6">
         {% include theme/cards/card-post.html
-          date=card.date
+          date=card_date
           title=card.title
           description=card.description
           thumbnail=card_thumbnail
           authors=card.authors
           author=card.author
-          categories=card.categories
+          categories=card.tags
           url=card.url
         %}
       </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -38,14 +38,21 @@ body_classes: page-post
           {% endfor %}
           </div>
         {% endif %}
+
+        {% if page.date %}
+          <div class="post-date mb-2" style="color: var(--color-base-text-2); font-size: 0.9rem;">
+            {{ page.date | date_to_long_string }}
+          </div>
+        {% endif %}
         
         <div class="content">{{ content }}</div>
 
-        {% if page.categories %}
-        <div class="categories">
+        {% if page.tags %}
+        <div class="categories mt-3">
         {% include framework/categories-badges.html 
-            categories=page.categories
+            categories=page.tags
         %}
+        </div>
         {% endif %}
         </div>
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -33,16 +33,17 @@ title: "Blog"
 
               {% for post in posts %}
                 {% assign post_thumbnail = post.thumbnail | default: post.image %}
+                {% assign post_date = post.date | date: "%Y-%m-%d" %}
                 <div class="col-12 col-md-12 col-lg-10 mb-6">
                   {% include theme/cards/card-post.html
-                    date=post.date
+                    date=post_date
                     title=post.title
                     description=post.description 
                     url=post.url
                     thumbnail=post_thumbnail
                     authors=post.authors
                     author=post.author
-                    categories=post.categories
+                    categories=post.tags
                     style="row"
                   %}
                 </div>


### PR DESCRIPTION
## What

Posts had neither publish date nor tags showing anywhere on the site — blog index cards, home page cards, or individual post pages.

## Why it was broken

Two separate bugs:

**Tags:** All posts use `tags` frontmatter but the blog index and home layout both passed `categories=post.categories` (nil) to the card template. Fixed to pass `post.tags`.

**Date:** `author.html` does `{% assign date = include.date %}` — Liquid includes share scope with their caller, so after the authors loop in `card-post.html` runs, the local `date` variable is clobbered to nil before the `{% if date %}` check. Fixed by renaming to `card_date` in both `card-post.html` copies.

Additionally, `post.date` as a Ruby Date object evaluates falsy in Liquid include parameter checks; pre-format to ISO string before passing.

**Post page:** The single-post layout had no date display at all. Added it above content.

## Changes

- `blog/index.html` — pass `post.tags` and pre-format date as ISO string
- `_layouts/home.html` — same
- `_includes/theme/cards/card-post.html` — rename `date` → `card_date`
- `_includes/framework/card-post.html` — same
- `_layouts/post.html` — add date display, use `page.tags` for badges